### PR TITLE
replace go-autocomplete with lsp-go, and go-flymake to flycheck

### DIFF
--- a/site-lisp/config/init-company-mode.el
+++ b/site-lisp/config/init-company-mode.el
@@ -112,6 +112,7 @@
 (require 'lsp-mode)
 (require 'lsp-ruby)
 (require 'lsp-python)
+(require 'lsp-go)
 (require 'company-lsp)
 (require 'desktop)
 

--- a/site-lisp/config/init-flycheck.el
+++ b/site-lisp/config/init-flycheck.el
@@ -92,6 +92,7 @@
                'ruby-mode-hook
                'python-mode-hook
                'swift-mode-hook
+               'go-mode-hook
                ))
   (add-hook hook '(lambda () (flycheck-mode 1))))
 

--- a/site-lisp/config/init-golang.el
+++ b/site-lisp/config/init-golang.el
@@ -82,7 +82,6 @@
 ;;; Require
 
 (require 'go-mode)
-(require 'go-autocomplete)
 (require 'gotest)
 
 ;;; Code:
@@ -124,6 +123,12 @@
    )
  go-mode-map
  )
+
+;; go mode use lsp-go for auto complete, YOU NEED to install go language server
+;; use command `go get -u github.com/sourcegraph/go-langserver`
+(add-hook 'go-mode-hook #'lsp-go-enable)
+(add-hook 'go-mode-hook (lambda ()
+                          (setq tab-width 4)))
 
 (provide 'init-golang)
 


### PR DESCRIPTION
Hi, I adjust go mode according to your configuration changes, `lsp-go` and `flycheck` is better for go mode. Thanks, your configuration is great.