### PR TITLE
fix(company): avoid duplicate of `company-elisp` backend

### DIFF
--- a/site-lisp/config/init-company-mode.el
+++ b/site-lisp/config/init-company-mode.el
@@ -148,7 +148,9 @@
               (add-hook 'emacs-lisp-mode-hook
                         #'(lambda ()
                             (require 'company-elisp)
-                            (push 'company-elisp company-backends)))
+                            (if (and (listp company-backends) (member 'company-elisp company-backends))
+                                company-backends
+                              (push 'company-elisp company-backends))))
 
               ;; Enable global.
               (global-company-mode)


### PR DESCRIPTION
When open times of elisp file, `company-backends` would like this
Emacs Version: emacs 29 native-comp

```
(company-elisp company-elisp company-elisp company-elisp
 (other-backends......))
```